### PR TITLE
Add workaround for JDK bug JDK-8014008 (https://bugs.openjdk.java.net…

### DIFF
--- a/src/main/java/net/sourceforge/prograde/policy/ProGradePolicy.java
+++ b/src/main/java/net/sourceforge/prograde/policy/ProGradePolicy.java
@@ -39,6 +39,8 @@ import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.KeyStore;
 import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
 import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.security.SecurityPermission;
@@ -916,4 +918,21 @@ public class ProGradePolicy extends Policy {
         }
         return certificates;
     }
+
+    @Override
+    public PermissionCollection getPermissions(CodeSource codesource) {
+        // code should not rely on this method, or at least use it correctly:
+        // https://bugs.openjdk.java.net/browse/JDK-8014008
+        // return them a new empty permissions object so jvisualvm etc work
+        // Workaround credit goes to Robert Muir (github.com/rmuir)
+        for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+            if ("sun.rmi.server.LoaderHandler".equals(element.getClassName()) &&
+                "loadClass".equals(element.getMethodName())) {
+                return new Permissions();
+            }
+        }
+        // return UNSUPPORTED_EMPTY_COLLECTION since it is safe.
+        return super.getPermissions(codesource);
+    }
+
 }


### PR DESCRIPTION
This workaround fixes the broken connection to the VM using JConsole, JVisualVM, etc. when using ProGradeJSM.
All credit goes to Robert Muir for his original post of this workaround in elastic search (https://github.com/elastic/elasticsearch/pull/14274/commits/c3381b24fe75e1c95f8d729839147086187ab62b)