### PR TITLE
Missing escapes for double quotes in permission name

### DIFF
--- a/src/main/java/net/sourceforge/prograde/generator/GeneratePolicyFromDeniedPermissions.java
+++ b/src/main/java/net/sourceforge/prograde/generator/GeneratePolicyFromDeniedPermissions.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import static net.sourceforge.prograde.generator.GeneratorUtils.createPrintablePermissionName;
 
 /**
  * DeniedPermissionListener implementation which generates a policy file with the denied permissions.
@@ -153,7 +154,7 @@ public final class GeneratePolicyFromDeniedPermissions implements DeniedPermissi
                     for (Permission p : csEntry.getValue()) {
                         pw.print("  permission " + p.getClass().getName());
                         if (p.getName() != null) {
-                            pw.print(" \"" + p.getName() + "\"");
+                            pw.print(" \"" + createPrintablePermissionName(p.getName()) + "\"");
                         }
                         if (p.getActions() != null && !p.getActions().equals("")) {
                             pw.print(", \"" + p.getActions() + "\"");

--- a/src/main/java/net/sourceforge/prograde/generator/GeneratorUtils.java
+++ b/src/main/java/net/sourceforge/prograde/generator/GeneratorUtils.java
@@ -1,0 +1,41 @@
+/*
+ * #%L
+ * pro-grade
+ * %%
+ * Copyright (C) 2013 - 2017 Ondřej Lukáš, Josef Cacek
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package net.sourceforge.prograde.generator;
+
+/**
+ * Util class for generating permissions.
+ *
+ * @author olukas
+ */
+final class GeneratorUtils {
+
+    private GeneratorUtils() {
+    }
+    
+    /**
+     * Method which transform permission name to the name which can be correctly used in policy file.
+     * 
+     * @param permissionName original permission name for transforming, cannot be null
+     * @return name of permission which can be correctly used in policy file
+     */
+    static String createPrintablePermissionName(String permissionName) {
+        return permissionName.replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/net/sourceforge/prograde/generator/PrintDeniedPermissions.java
+++ b/src/main/java/net/sourceforge/prograde/generator/PrintDeniedPermissions.java
@@ -22,6 +22,7 @@ package net.sourceforge.prograde.generator;
 import java.io.PrintStream;
 import java.security.Permission;
 import java.security.ProtectionDomain;
+import static net.sourceforge.prograde.generator.GeneratorUtils.createPrintablePermissionName;
 
 /**
  * Simple implementation of {@link DeniedPermissionListener} which prints the denied permissions to given {@link PrintStream}
@@ -58,7 +59,7 @@ public final class PrintDeniedPermissions implements DeniedPermissionListener {
     public void permissionDenied(final ProtectionDomain pd, final Permission perm) {
         final StringBuilder sb = new StringBuilder(">> Denied permission ");
         sb.append(perm.getClass().getName()).append(" \"") //
-                .append(perm.getName()).append("\""); //
+                .append(createPrintablePermissionName(perm.getName())).append("\""); //
         if (perm.getActions()!=null && !perm.getActions().equals("")) {
                 sb.append(", \"").append(perm.getActions()).append("\"");
         }


### PR DESCRIPTION
Fix for #37 .
@kwart could you please review it?